### PR TITLE
Compact and reduce alerts so they don't dominate the diff

### DIFF
--- a/flux-helm-diff.sh
+++ b/flux-helm-diff.sh
@@ -172,25 +172,27 @@ helm_template() {
     # Check if chart is using .Capabilities.KubeVersion
     grep -R --include='*.yaml' --include='*.yml' --include='*.tpl' ".Capabilities.KubeVersion" "${chart_temp_path}" > /dev/null && {
         echo "${ref} uses \".Capabilities.KubeVersion\"" >&2
-        if [[ ${#kube_version} -eq 0 ]]; then
-            output_msg TIP "Chart in \`${ref}\` ref uses [\`.Capabilities.KubeVersion\`](https://helm.sh/docs/chart_template_guide/builtin_objects/) but is not specifying a Kubernetes version to simulate. Will use Helm's default Kubernetes version: \`${helm_default_kube_version}\`." \
-                "See [Simulating Capabilities](https://github.com/marketplace/actions/flux-helm-diff#simulating-capabilities) for details."
-            helm_kube_version=() # treat as array, to avoid adding single-quotes
-        else
-            output_msg TIP "Chart in \`${ref}\` ref uses [\`.Capabilities.KubeVersion\`](https://helm.sh/docs/chart_template_guide/builtin_objects/) and is simulating the following Kubernetes version: \`${kube_version}\`"
-            helm_kube_version=(--kube-version "${kube_version}") # treat as array, to avoid adding single-quotes
+        if [[ "${ref}" == "head" ]]; then
+            if [[ ${#kube_version} -eq 0 ]]; then
+                output_msg TIP "Chart in \`${ref}\` ref uses [\`.Capabilities.KubeVersion\`](https://helm.sh/docs/chart_template_guide/builtin_objects/) but is not specifying a Kubernetes version to simulate. Will use Helm's default Kubernetes version: \`${helm_default_kube_version}\`. See [Simulating Capabilities](https://github.com/marketplace/actions/flux-helm-diff#simulating-capabilities) for details."
+                helm_kube_version=() # treat as array, to avoid adding single-quotes
+            else
+                output_msg TIP "Chart in \`${ref}\` ref uses [\`.Capabilities.KubeVersion\`](https://helm.sh/docs/chart_template_guide/builtin_objects/) and is simulating the following Kubernetes version: \`${kube_version}\`"
+                helm_kube_version=(--kube-version "${kube_version}") # treat as array, to avoid adding single-quotes
+            fi
         fi
     }
 
     # Check if chart is using .Capabilities.APIVersions
     grep -R --include='*.yaml' --include='*.yml' --include='*.tpl' ".Capabilities.APIVersions" "${chart_temp_path}" > /dev/null && {
         echo "${ref} uses \".Capabilities.APIVersions\"" >&2
-        if [[ ${#api_versions[@]} -eq 0 ]]; then
-            output_msg IMPORTANT "Chart in \`${ref}\` ref uses [\`.Capabilities.APIVersions\`](https://helm.sh/docs/chart_template_guide/builtin_objects/) but is not specifying any APIs to simulate. Only the built-in API versions are available for templating." \
-                "See [Simulating Capabilities](https://github.com/marketplace/actions/flux-helm-diff#simulating-capabilities) for details."
-        else
-            output_msg TIP "Chart in \`${ref}\` ref uses [\`.Capabilities.APIVersions\`](https://helm.sh/docs/chart_template_guide/builtin_objects/) and is simulating the following APIs, in addition to the built-in:" \
-                "$(printf "\`%s\`\n" "${api_versions[@]}")"
+        if [[ "${ref}" == "head" ]]; then
+            if [[ ${#api_versions[@]} -eq 0 ]]; then
+                output_msg IMPORTANT "Chart in \`${ref}\` ref uses [\`.Capabilities.APIVersions\`](https://helm.sh/docs/chart_template_guide/builtin_objects/) but is not specifying any APIs to simulate. Only the built-in API versions are available for templating. See [Simulating Capabilities](https://github.com/marketplace/actions/flux-helm-diff#simulating-capabilities) for details."
+            else
+                output_msg TIP "Chart in \`${ref}\` ref uses [\`.Capabilities.APIVersions\`](https://helm.sh/docs/chart_template_guide/builtin_objects/) and is simulating the following APIs, in addition to the built-in:" \
+                    "$(printf "\`%s\`\n" "${api_versions[@]}")"
+            fi
         fi
     }
 

--- a/flux-helm-diff.sh
+++ b/flux-helm-diff.sh
@@ -21,7 +21,6 @@ output_msg() {
         # Message line(s)
         for msg in "$@"; do
             echo "> ${msg}"
-            echo '>'
         done
         echo
     } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Still making up my mind if removing the blank line is enough, or it should actually go into the same paragraph.

Yes, it's a bit less readable, but the alerts tend to dominate a bit as it is. To achieve the latter:

```bash
echo -n '>'
# Message line(s)
for msg in "$@"; do
    echo " ${msg}"
done
```

Another option is to aggregate "tips" and "importants" for each chart, and try and format it nice and readable.